### PR TITLE
Add minimal workflow runner

### DIFF
--- a/components/LogViewer.tsx
+++ b/components/LogViewer.tsx
@@ -1,1 +1,9 @@
-// LogViewer.tsx placeholder
+import React from 'react';
+
+export default function LogViewer({ logs }: { logs: string[] }) {
+  return (
+    <pre style={{ background: '#111', color: '#0f0', padding: '1em', height: '200px', overflow: 'auto' }}>
+      {logs.join('\n')}
+    </pre>
+  );
+}

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -1,1 +1,59 @@
-// engine.ts placeholder
+import { WorkflowSpec, PromptNodeSpec, LLMNodeSpec, RunOutput } from './store';
+
+export interface WorkflowEvent {
+  type: 'log' | 'error' | 'done';
+  message?: string;
+  data?: any;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function simulateLLM(prompt: string): Promise<string> {
+  // pretend to call an LLM and echo the prompt back
+  await delay(100);
+  return `LLM response for: ${prompt}`;
+}
+
+async function callWithTimeout(fn: () => Promise<string>, timeoutMs: number, retries: number, onEvent?: (ev: WorkflowEvent) => void): Promise<string> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await Promise.race([
+        fn(),
+        new Promise<string>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
+      ]);
+      return res as string;
+    } catch (err) {
+      if (attempt >= retries) throw err;
+      onEvent?.({ type: 'log', message: 'Retrying after timeout' });
+    }
+  }
+  throw new Error('call failed');
+}
+
+export async function runWorkflow(spec: WorkflowSpec, onEvent?: (ev: WorkflowEvent) => void): Promise<RunOutput> {
+  const logs: string[] = [];
+  function log(msg: string) {
+    logs.push(msg);
+    onEvent?.({ type: 'log', message: msg });
+  }
+
+  try {
+    const promptNode = spec.nodes[0] as PromptNodeSpec;
+    const llmNode = spec.nodes[1] as LLMNodeSpec;
+
+    log(`Prompting: ${promptNode.prompt}`);
+    const result = await callWithTimeout(() => simulateLLM(promptNode.prompt), 1000, 1, onEvent);
+    log(`LLM result: ${result}`);
+
+    const output: RunOutput = { logs, status: 'success', output: result };
+    onEvent?.({ type: 'done', data: result });
+    return output;
+  } catch (err: any) {
+    const message = err && err.message ? err.message : String(err);
+    logs.push(message);
+    onEvent?.({ type: 'error', message });
+    return { logs, status: 'error', error: message };
+  }
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,1 +1,47 @@
-// store.ts placeholder
+export interface PromptNodeSpec {
+  id: string;
+  type: 'PromptNode';
+  prompt: string;
+}
+
+export interface LLMNodeSpec {
+  id: string;
+  type: 'LLMNode';
+}
+
+export type NodeSpec = PromptNodeSpec | LLMNodeSpec;
+
+export interface WorkflowSpec {
+  id: string;
+  nodes: NodeSpec[];
+}
+
+export interface RunOutput {
+  logs: string[];
+  status: 'running' | 'success' | 'error';
+  output?: string;
+  error?: string;
+}
+
+const workflowStore = new Map<string, WorkflowSpec>();
+const runStore = new Map<string, RunOutput>();
+
+export function saveWorkflow(spec: WorkflowSpec) {
+  workflowStore.set(spec.id, spec);
+}
+
+export function getWorkflow(id: string): WorkflowSpec | undefined {
+  return workflowStore.get(id);
+}
+
+export function listWorkflowIds(): string[] {
+  return Array.from(workflowStore.keys());
+}
+
+export function saveRun(id: string, run: RunOutput) {
+  runStore.set(id, run);
+}
+
+export function getRun(id: string): RunOutput | undefined {
+  return runStore.get(id);
+}

--- a/pages/api/workflows/[id]/run.ts
+++ b/pages/api/workflows/[id]/run.ts
@@ -1,1 +1,30 @@
-// [id]/run.ts placeholder
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getWorkflow, saveRun } from '../../../lib/store';
+import { runWorkflow, WorkflowEvent } from '../../../lib/engine';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  const id = req.query.id as string;
+  const spec = getWorkflow(id);
+  if (!spec) {
+    res.status(404).end('Not found');
+    return;
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  const events: WorkflowEvent[] = [];
+
+  await runWorkflow(spec, (ev) => {
+    events.push(ev);
+    res.write(`data: ${JSON.stringify(ev)}\n\n`);
+  }).then((result) => saveRun(id, result));
+
+  res.end();
+}

--- a/pages/api/workflows/index.ts
+++ b/pages/api/workflows/index.ts
@@ -1,1 +1,26 @@
-// index.ts placeholder
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { WorkflowSpec, saveWorkflow, listWorkflowIds } from '../../../lib/store';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    try {
+      const spec = req.body as WorkflowSpec;
+      if (!spec || !spec.id || !Array.isArray(spec.nodes) || spec.nodes.length !== 2) {
+        res.status(400).json({ error: 'Invalid spec' });
+        return;
+      }
+      if (spec.nodes[0].type !== 'PromptNode' || spec.nodes[1].type !== 'LLMNode') {
+        res.status(400).json({ error: 'Spec must contain PromptNode then LLMNode' });
+        return;
+      }
+      saveWorkflow(spec);
+      res.status(201).json({ id: spec.id });
+    } catch (err: any) {
+      res.status(400).json({ error: err.message });
+    }
+  } else if (req.method === 'GET') {
+    res.status(200).json({ ids: listWorkflowIds() });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,1 +1,61 @@
-// index.tsx placeholder
+import { useState } from 'react';
+import LogViewer from '../components/LogViewer';
+
+export default function Home() {
+  const [spec, setSpec] = useState(`{
+  "id": "demo",
+  "nodes": [
+    { "id": "p1", "type": "PromptNode", "prompt": "Hello" },
+    { "id": "l1", "type": "LLMNode" }
+  ]
+}`);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const run = async () => {
+    setLogs([]);
+    try {
+      const response = await fetch('/api/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: spec,
+      });
+      if (!response.ok) {
+        const err = await response.json();
+        setLogs([`Error: ${err.error}`]);
+        return;
+      }
+      const data = await response.json();
+      const id = data.id;
+
+      const es = new EventSource(`/api/workflows/${id}/run`);
+      setRunning(true);
+      es.onmessage = (e) => {
+        const evt = JSON.parse(e.data);
+        if (evt.type === 'log') {
+          setLogs((prev) => [...prev, evt.message]);
+        } else if (evt.type === 'error') {
+          setLogs((prev) => [...prev, `Error: ${evt.message}`]);
+        } else if (evt.type === 'done') {
+          setLogs((prev) => [...prev, 'Done']);
+          es.close();
+          setRunning(false);
+        }
+      };
+    } catch (err: any) {
+      setLogs([`Error: ${err.message}`]);
+    }
+  };
+
+  return (
+    <div style={{ padding: '1em' }}>
+      <textarea value={spec} onChange={(e) => setSpec(e.target.value)} rows={10} cols={80} />
+      <div>
+        <button onClick={run} disabled={running} style={{ marginTop: '1em' }}>
+          Run Workflow
+        </button>
+      </div>
+      <LogViewer logs={logs} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement in-memory store
- add simple orchestration engine with retry and timeouts
- expose workflow save API and run API with SSE
- build sample Next.js UI with log viewer

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d3b6c6cf0832898f54738dfc694fc