### PR TITLE
Fix workflow run endpoint imports

### DIFF
--- a/pages/api/workflows/[id]/run.ts
+++ b/pages/api/workflows/[id]/run.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getWorkflow, saveRun } from '../../../lib/store';
-import { runWorkflow, WorkflowEvent } from '../../../lib/engine';
+import { getWorkflow, saveRun } from '../../../../lib/store';
+import { runWorkflow, WorkflowEvent } from '../../../../lib/engine';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {


### PR DESCRIPTION
## Summary
- fix import paths for the run workflow API so they resolve correctly

## Testing
- `npm test` *(fails: argument of type not assignable to parameter of type 'WorkflowSpec')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ee9e757708328ab9f51fdd67637d0