### PR TITLE
Add callback on run complete

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,7 +66,12 @@ export default function Home() {
           Run Workflow
         </button>
       </div>
-      {workflowId && <RunLogSubscriber workflowId={workflowId} />}
+      {workflowId && (
+        <RunLogSubscriber
+          workflowId={workflowId}
+          onDone={() => setRunning(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- notify components when `RunLogSubscriber` finishes streaming logs
- reset running state in the homepage when streaming ends

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef767e4808328a5b343bbafee968e