### PR TITLE
Extend workflow template support

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -35,7 +35,7 @@ describe('workflows API', () => {
     const spec: WorkflowSpec = {
       id: 'a',
       nodes: [
-        { id: 'p', type: 'PromptNode', prompt: 'hi' },
+        { id: 'p', type: 'PromptNode', template: 'hi', input: {} },
         { id: 'l', type: 'LLMNode' },
       ],
     };
@@ -67,7 +67,7 @@ describe('run route', () => {
     const spec: WorkflowSpec = {
       id: 'stream',
       nodes: [
-        { id: 'p', type: 'PromptNode', prompt: 'test' },
+        { id: 'p', type: 'PromptNode', template: 'test', input: {} },
         { id: 'l', type: 'LLMNode' },
       ],
     };
@@ -86,7 +86,7 @@ describe('run route', () => {
     const spec: WorkflowSpec = {
       id: 'persist',
       nodes: [
-        { id: 'p', type: 'PromptNode', prompt: 'hi' },
+        { id: 'p', type: 'PromptNode', template: 'hi', input: {} },
         { id: 'l', type: 'LLMNode' },
       ],
     };
@@ -101,7 +101,7 @@ describe('run route', () => {
     const spec2: WorkflowSpec = {
       id: 'persist',
       nodes: [
-        { id: 'p', type: 'PromptNode', prompt: 'bye' },
+        { id: 'p', type: 'PromptNode', template: 'bye', input: {} },
         { id: 'l', type: 'LLMNode' },
       ],
     };

--- a/__tests__/engine.test.ts
+++ b/__tests__/engine.test.ts
@@ -10,7 +10,7 @@ jest.mock('openai', () => {
 });
 process.env.OPENAI_API_KEY = 'test';
 
-import { runWorkflow, callWithTimeout, WorkflowEvent } from '../lib/engine';
+import { runWorkflow, callWithTimeout, WorkflowEvent, mergePrompt } from '../lib/engine';
 import { WorkflowSpec } from '../lib/store';
 
 describe('runWorkflow', () => {
@@ -18,7 +18,7 @@ describe('runWorkflow', () => {
     const spec: WorkflowSpec = {
       id: 'wf1',
       nodes: [
-        { id: 'n1', type: 'PromptNode', prompt: 'hello' },
+        { id: 'n1', type: 'PromptNode', template: 'hello', input: {} },
         { id: 'n2', type: 'LLMNode' },
       ],
     };
@@ -36,7 +36,7 @@ describe('runWorkflow', () => {
     const spec: WorkflowSpec = {
       id: 'wf2',
       nodes: [
-        { id: 'p', type: 'PromptNode', prompt: 'hi' },
+        { id: 'p', type: 'PromptNode', template: 'hi', input: {} },
         { id: 'l', type: 'LLMNode' },
       ],
     };
@@ -47,6 +47,17 @@ describe('runWorkflow', () => {
     expect(events[2]).toEqual({ node: 'l', status: 'running' });
     expect(events[3].node).toBe('l');
     expect(['success', 'failure']).toContain(events[3].status);
+  });
+});
+
+describe('mergePrompt', () => {
+  test('replaces placeholders', () => {
+    const result = mergePrompt('Hello {{name}}', { name: 'Bob' });
+    expect(result).toBe('Hello Bob');
+  });
+
+  test('throws for missing input', () => {
+    expect(() => mergePrompt('Hi {{name}}', {})).toThrow('Missing value for name');
   });
 });
 

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -40,6 +40,15 @@ export async function callWithTimeout(
   throw new Error('call failed');
 }
 
+export function mergePrompt(template: string, input: Record<string, string>): string {
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {
+    if (input[key] === undefined) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    return input[key];
+  });
+}
+
 export async function runWorkflow(
   spec: WorkflowSpec,
   onEvent?: (ev: WorkflowEvent) => void,
@@ -50,12 +59,21 @@ export async function runWorkflow(
   const llmNode = spec.nodes[1] as LLMNodeSpec;
 
   onEvent?.({ node: promptNode.id, status: 'running' });
-  logs.push(`Prompting: ${promptNode.prompt}`);
-  onEvent?.({ node: promptNode.id, status: 'success', output: promptNode.prompt });
+  let prompt: string;
+  try {
+    prompt = mergePrompt(promptNode.template, promptNode.input || {});
+  } catch (err: any) {
+    const msg = err && err.message ? err.message : String(err);
+    logs.push(msg);
+    onEvent?.({ node: promptNode.id, status: 'failure', error: msg });
+    return { logs, status: 'error', error: msg };
+  }
+  logs.push(`Prompting: ${prompt}`);
+  onEvent?.({ node: promptNode.id, status: 'success', output: prompt });
 
   onEvent?.({ node: llmNode.id, status: 'running' });
   try {
-    const result = await callWithTimeout(() => callOpenAI(promptNode.prompt), 1000, 1);
+    const result = await callWithTimeout(() => callOpenAI(prompt), 1000, 1);
     logs.push(`LLM result: ${result}`);
     onEvent?.({ node: llmNode.id, status: 'success', output: result });
     return { logs, status: 'success', output: result };

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,7 +1,8 @@
 export interface PromptNodeSpec {
   id: string;
   type: 'PromptNode';
-  prompt: string;
+  template: string;
+  input: Record<string, string>;
 }
 
 export interface LLMNodeSpec {

--- a/pages/api/workflows/index.ts
+++ b/pages/api/workflows/index.ts
@@ -13,6 +13,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
         res.status(400).json({ error: 'Spec must contain PromptNode then LLMNode' });
         return;
       }
+      const prompt = spec.nodes[0] as any;
+      if (typeof prompt.template !== 'string' || typeof prompt.input !== 'object') {
+        res.status(400).json({ error: 'Prompt node must have template and input' });
+        return;
+      }
       saveWorkflow(spec);
       res.status(201).json({ id: spec.id, spec });
     } catch (err: any) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,9 @@ import RunLogSubscriber from '../components/RunLogSubscriber';
 
 export default function Home() {
   const [specText, setSpecText] = useState('');
+  const [inputText, setInputText] = useState('');
   const [isValid, setIsValid] = useState(false);
+  const [inputValid, setInputValid] = useState(true);
   const [workflowId, setWorkflowId] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
 
@@ -18,12 +20,27 @@ export default function Home() {
     }
   };
 
+  const onInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    setInputText(val);
+    try {
+      JSON.parse(val || '{}');
+      setInputValid(true);
+    } catch {
+      setInputValid(false);
+    }
+  };
+
   const run = async () => {
-    if (!isValid) return;
+    if (!isValid || !inputValid) return;
     setRunning(true);
     setWorkflowId(null);
     try {
       const parsed = JSON.parse(specText);
+      const input = inputText ? JSON.parse(inputText) : {};
+      if (parsed.nodes && parsed.nodes[0] && parsed.nodes[0].type === 'PromptNode') {
+        parsed.nodes[0].input = input;
+      }
       const response = await fetch('/api/workflows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -51,10 +68,17 @@ export default function Home() {
         rows={10}
         style={{ width: '100%' }}
       />
+      <textarea
+        value={inputText}
+        onChange={onInputChange}
+        rows={4}
+        style={{ width: '100%', marginTop: '1em' }}
+        placeholder="Runtime input as JSON"
+      />
       <div>
         <button
           onClick={run}
-          disabled={!isValid || running}
+          disabled={!isValid || !inputValid || running}
           style={{ marginTop: '1em' }}
         >
           Run Workflow


### PR DESCRIPTION
## Summary
- add `template` and `input` fields to `PromptNodeSpec`
- merge templates with runtime input when running workflows
- validate new fields in `/api/workflows`
- allow providing runtime input in the UI
- test template merging and failure cases

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2324fa508328bb5eade8c9ce314f