### PR TITLE
Remove runtime input field and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ Usage:
 <RunLogSubscriber workflowId="demo" />
 ```
 
+### Workflow Spec
+
+`PromptNode` now contains a `template` string and an `input` object. Provide all
+prompt variables inside the workflow JSON itself. The UI offers a single text
+area where you paste the entire spec and run it.
+
+Example:
+
+```json
+{
+  "id": "demo",
+  "nodes": [
+    {
+      "id": "p1",
+      "type": "PromptNode",
+      "template": "Hello {{name}}",
+      "input": { "name": "World" }
+    },
+    { "id": "l1", "type": "LLMNode" }
+  ]
+}
+```
+
 ### Key Architectural Decisions
 
 - **SSE vs WebSocket** – SSE keeps the log streaming implementation simple and requires no extra client library.
@@ -64,6 +87,8 @@ npm run dev
 ```
 
 Open `http://localhost:3000` in your browser.
+Paste your workflow JSON into the textarea and click **Run Workflow** to execute
+it. Logs for the latest run will appear below the button.
 
 ### Running Tests
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,9 +3,7 @@ import RunLogSubscriber from '../components/RunLogSubscriber';
 
 export default function Home() {
   const [specText, setSpecText] = useState('');
-  const [inputText, setInputText] = useState('');
   const [isValid, setIsValid] = useState(false);
-  const [inputValid, setInputValid] = useState(true);
   const [workflowId, setWorkflowId] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
 
@@ -20,27 +18,13 @@ export default function Home() {
     }
   };
 
-  const onInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const val = e.target.value;
-    setInputText(val);
-    try {
-      JSON.parse(val || '{}');
-      setInputValid(true);
-    } catch {
-      setInputValid(false);
-    }
-  };
 
   const run = async () => {
-    if (!isValid || !inputValid) return;
+    if (!isValid) return;
     setRunning(true);
     setWorkflowId(null);
     try {
       const parsed = JSON.parse(specText);
-      const input = inputText ? JSON.parse(inputText) : {};
-      if (parsed.nodes && parsed.nodes[0] && parsed.nodes[0].type === 'PromptNode') {
-        parsed.nodes[0].input = input;
-      }
       const response = await fetch('/api/workflows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -68,17 +52,10 @@ export default function Home() {
         rows={10}
         style={{ width: '100%' }}
       />
-      <textarea
-        value={inputText}
-        onChange={onInputChange}
-        rows={4}
-        style={{ width: '100%', marginTop: '1em' }}
-        placeholder="Runtime input as JSON"
-      />
       <div>
         <button
           onClick={run}
-          disabled={!isValid || !inputValid || running}
+          disabled={!isValid || running}
           style={{ marginTop: '1em' }}
         >
           Run Workflow


### PR DESCRIPTION
## Summary
- simplify UI to a single workflow textarea
- document workflow spec with template and input
- explain how to run workflow in updated README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f173f7cc88328a4c4bd763b63dd69