### PR TITLE
Improve error logging

### DIFF
--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -1,5 +1,6 @@
 import { WorkflowSpec, PromptNodeSpec, LLMNodeSpec, RunOutput } from './store';
 import { Configuration, OpenAIApi } from 'openai';
+import { logError } from './logger';
 
 export interface WorkflowEvent {
   node: string;
@@ -72,6 +73,7 @@ export async function runWorkflow(
     prompt = mergePrompt(promptNode.template, promptNode.input || {});
   } catch (err: any) {
     const msg = err && err.message ? err.message : String(err);
+    logError(err);
     logs.push(msg);
     onEvent?.({ node: promptNode.id, status: 'failure', error: msg });
     return { logs, status: 'error', error: msg };
@@ -87,6 +89,7 @@ export async function runWorkflow(
     return { logs, status: 'success', output: result };
   } catch (err: any) {
     const message = err && err.message ? err.message : String(err);
+    logError(err);
     logs.push(message);
     onEvent?.({ node: llmNode.id, status: 'failure', error: message });
     return { logs, status: 'error', error: message };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+
+const logDir = path.join(process.cwd(), 'logs');
+const logFile = path.join(logDir, 'server.log');
+
+function ensureLogDir() {
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+}
+
+export function logError(err: any) {
+  const msg = err instanceof Error ? err.stack || err.message : String(err);
+  console.error(msg);
+  try {
+    ensureLogDir();
+    fs.appendFileSync(logFile, msg + '\n');
+  } catch (e) {
+    console.error('Failed to write to log file', e);
+  }
+}

--- a/pages/api/workflows/[id]/latest.ts
+++ b/pages/api/workflows/[id]/latest.ts
@@ -1,16 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getRun } from '../../../../lib/store';
+import { logError } from '../../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     res.status(405).end();
     return;
   }
-  const id = req.query.id as string;
-  const run = getRun(id);
-  if (!run) {
-    res.status(404).end('Not found');
-    return;
+  try {
+    const id = req.query.id as string;
+    const run = getRun(id);
+    if (!run) {
+      res.status(404).end('Not found');
+      return;
+    }
+    res.status(200).json(run);
+  } catch (err) {
+    logError(err);
+    res.status(500).end('Internal error');
   }
-  res.status(200).json(run);
 }

--- a/pages/api/workflows/index.ts
+++ b/pages/api/workflows/index.ts
@@ -1,31 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { WorkflowSpec, saveWorkflow, listWorkflowIds } from '../../../lib/store';
+import { logError } from '../../../lib/logger';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === 'POST') {
-    try {
-      const spec = req.body as WorkflowSpec;
-      if (!spec || !spec.id || !Array.isArray(spec.nodes) || spec.nodes.length !== 2) {
-        res.status(400).json({ error: 'Invalid spec' });
-        return;
+  try {
+    if (req.method === 'POST') {
+      try {
+        const spec = req.body as WorkflowSpec;
+        if (!spec || !spec.id || !Array.isArray(spec.nodes) || spec.nodes.length !== 2) {
+          res.status(400).json({ error: 'Invalid spec' });
+          return;
+        }
+        if (spec.nodes[0].type !== 'PromptNode' || spec.nodes[1].type !== 'LLMNode') {
+          res.status(400).json({ error: 'Spec must contain PromptNode then LLMNode' });
+          return;
+        }
+        const prompt = spec.nodes[0] as any;
+        if (typeof prompt.template !== 'string' || typeof prompt.input !== 'object') {
+          res.status(400).json({ error: 'Prompt node must have template and input' });
+          return;
+        }
+        saveWorkflow(spec);
+        res.status(201).json({ id: spec.id, spec });
+      } catch (err: any) {
+        logError(err);
+        res.status(400).json({ error: err.message });
       }
-      if (spec.nodes[0].type !== 'PromptNode' || spec.nodes[1].type !== 'LLMNode') {
-        res.status(400).json({ error: 'Spec must contain PromptNode then LLMNode' });
-        return;
-      }
-      const prompt = spec.nodes[0] as any;
-      if (typeof prompt.template !== 'string' || typeof prompt.input !== 'object') {
-        res.status(400).json({ error: 'Prompt node must have template and input' });
-        return;
-      }
-      saveWorkflow(spec);
-      res.status(201).json({ id: spec.id, spec });
-    } catch (err: any) {
-      res.status(400).json({ error: err.message });
-    }
   } else if (req.method === 'GET') {
     res.status(200).json({ ids: listWorkflowIds() });
   } else {
     res.status(405).end();
+  }
+  } catch (err) {
+    logError(err);
+    res.status(500).end('Internal error');
   }
 }


### PR DESCRIPTION
## Summary
- add a simple server-side logger that writes to `logs/server.log`
- log caught errors from workflow engine
- add error handling and logging to API routes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4147ddec8328afee4a671bef84f4